### PR TITLE
quadruple carousel text shadow to fix rodrigo-brito/morfeu-theme#1

### DIFF
--- a/assets/sass/bootstrap/bootstrap/_variables.scss
+++ b/assets/sass/bootstrap/bootstrap/_variables.scss
@@ -808,7 +808,10 @@ $breadcrumb-separator:          "/" !default;
 //
 //##
 
-$carousel-text-shadow:                        0 1px 2px rgba(0,0,0,.6) !default;
+$carousel-text-shadow:                         1px  1px 2px rgba(0,0,0,.6),
+                                               1px -1px 2px rgba(0,0,0,.6),
+                                              -1px  1px 2px rgba(0,0,0,.6),
+                                              -1px -1px 2px rgba(0,0,0,.6) !default;
 
 $carousel-control-color:                      #fff !default;
 $carousel-control-width:                      15% !default;

--- a/style.css
+++ b/style.css
@@ -6528,7 +6528,7 @@ button.close {
 	font-size: 20px;
 	color: #fff;
 	text-align: center;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+	text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6), 1px -1px 2px rgba(0, 0, 0, 0.6), -1px 1px 2px rgba(0, 0, 0, 0.6), -1px -1px 2px rgba(0, 0, 0, 0.6);
 }
 .carousel-control.left {
 	background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
@@ -6627,7 +6627,7 @@ button.close {
 	padding-bottom: 20px;
 	color: #fff;
 	text-align: center;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+	text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6), 1px -1px 2px rgba(0, 0, 0, 0.6), -1px 1px 2px rgba(0, 0, 0, 0.6), -1px -1px 2px rgba(0, 0, 0, 0.6);
 }
 .carousel-caption .btn, .carousel-caption .author-sinal, .carousel-caption input[type="submit"],
 .carousel-caption input[type="reset"],


### PR DESCRIPTION
the shadow now is in all directions instead of just one direction --> makes it standout more on bright backgrounds

examples
![screenshot_1](https://user-images.githubusercontent.com/2734298/31306363-ff45026c-ab4e-11e7-8cf0-47902200709b.png)
![screenshot_2](https://user-images.githubusercontent.com/2734298/31306364-ff468bfa-ab4e-11e7-8973-34e815c70b02.png)
